### PR TITLE
ci: cache gettext build output to skip rebuild on unrelated PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,22 @@ jobs:
             ccache-
       - id: machine-arch
         run: echo "name=$(arch)" | tee -a "$GITHUB_OUTPUT"
+      # gettext is the slowest dep (5-7 min). Cache its build output keyed on
+      # version + configs so the only PRs that pay the gettext build cost are
+      # those that actually bump gettext itself.
+      - id: gettext-meta
+        run: |
+          set -e
+          ver=$(awk '$1 == "gettext_version" { print $3 }' Makefile)
+          h=$(awk '
+            /^gettext_version/ { print; next }
+            /^gettext_configs/ { in_block=1; print; if ($0 !~ /\\$/) in_block=0; next }
+            in_block { print; if ($0 !~ /\\$/) in_block=0 }
+          ' Makefile | shasum -a 256 | cut -c1-12)
+          {
+            echo "version=$ver"
+            echo "hash=$h"
+          } | tee -a "$GITHUB_OUTPUT"
       - run: make
       # Build dependencies in order
       - run: make download-zlib
@@ -60,13 +76,57 @@ jobs:
       - run: make download-pcre2
       - run: make install-pcre2
       - run: make download-gettext
+      - id: cache-gettext
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            usr/.stamps/gettext-${{ steps.gettext-meta.outputs.version }}
+            usr/lib/libintl*
+            usr/lib/libgettext*
+            usr/lib/libtextstyle*
+            usr/include/libintl.h
+            usr/include/gettext-po.h
+            usr/include/textstyle*
+            usr/bin/msg*
+            usr/bin/xgettext
+            usr/bin/gettext
+            usr/bin/ngettext
+            usr/bin/envsubst
+            usr/bin/recode-sr-latin
+            usr/bin/gettextize
+            usr/bin/autopoint
+            usr/share/gettext
+            usr/share/locale
+          key: gettext-${{ matrix.os }}-${{ runner.arch }}-${{ steps.gettext-meta.outputs.hash }}
       - run: make install-gettext
+      - if: github.ref_name == 'main' && steps.cache-gettext.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            usr/.stamps/gettext-${{ steps.gettext-meta.outputs.version }}
+            usr/lib/libintl*
+            usr/lib/libgettext*
+            usr/lib/libtextstyle*
+            usr/include/libintl.h
+            usr/include/gettext-po.h
+            usr/include/textstyle*
+            usr/bin/msg*
+            usr/bin/xgettext
+            usr/bin/gettext
+            usr/bin/ngettext
+            usr/bin/envsubst
+            usr/bin/recode-sr-latin
+            usr/bin/gettextize
+            usr/bin/autopoint
+            usr/share/gettext
+            usr/share/locale
+          key: gettext-${{ matrix.os }}-${{ runner.arch }}-${{ steps.gettext-meta.outputs.hash }}
       - run: ccache -s
       # Build Git
       - run: make download-git
       - run: make install-git
       - run: ccache -s
-      - if: github.ref_name == 'master'
+      - if: github.ref_name == 'main'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 ## sasaplus1/macos-git
 
+/usr/.stamps/**
+!/usr/.stamps/.gitkeep
+
 /usr/bin/**
 !/usr/bin/.gitkeep
 

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ all: ## output targets
 
 .PHONY: clean
 clean: ## remove files
-	$(RM) -r $(root)/usr/bin/* $(root)/usr/include/* $(root)/usr/lib/* $(root)/usr/libexec/* $(root)/usr/man/* $(root)/usr/share/* $(root)/usr/src/*
+	$(RM) -r $(root)/usr/.stamps/* $(root)/usr/bin/* $(root)/usr/include/* $(root)/usr/lib/* $(root)/usr/libexec/* $(root)/usr/man/* $(root)/usr/share/* $(root)/usr/src/*
 
 .PHONY: install
 install: ## install git and dependencies
@@ -158,14 +158,23 @@ install-pcre2: ## [subtarget] install pcre2
 	make -j$(nproc) -C '$(root)/usr/src/pcre2-$(pcre2_version)'
 	make install -C '$(root)/usr/src/pcre2-$(pcre2_version)'
 
+gettext_stamp := $(prefix)/.stamps/gettext-$(gettext_version)
+
 .PHONY: install-gettext
 install-gettext: CFLAGS := -Wno-incompatible-function-pointer-types
 install-gettext: ## [subtarget] install gettext
+install-gettext: $(gettext_stamp)
+
+# stamp file lets `make` short-circuit when the cached output is restored from CI cache
+$(gettext_stamp): CFLAGS := -Wno-incompatible-function-pointer-types
+$(gettext_stamp):
+	$(MAKE) download-gettext
 	@test -d '$(root)/usr/src/gettext-$(gettext_version)' || \
 		tar fvx '$(root)/usr/src/gettext-$(gettext_version).tar.gz' -C '$(root)/usr/src'
 	cd '$(root)/usr/src/gettext-$(gettext_version)' && CFLAGS='$(CFLAGS)' ./configure --prefix='$(prefix)' $(gettext_configs)
 	make -j$(nproc) -C '$(root)/usr/src/gettext-$(gettext_version)'
 	make install -C '$(root)/usr/src/gettext-$(gettext_version)'
+	@mkdir -p '$(prefix)/.stamps' && touch '$@'
 
 .PHONY: install-git
 # Clean PATH to exclude MacPorts/Homebrew, use only system and our binaries


### PR DESCRIPTION
## Summary

- gettext dominates CI time (446s on macos-15, 293s on macos-14) but is rarely the dep that actually changes. Cache its build outputs keyed on `gettext_version` + `gettext_configs` hash so unrelated Renovate PRs (git/zlib/curl/expat/pcre2/GHA bumps) skip the rebuild
- Convert `install-gettext` to depend on a stamp file `usr/.stamps/gettext-<version>` so `make` short-circuits when the cached output is restored
- Fix a pre-existing dead-code reference: the ccache save step gated on `github.ref_name == 'master'`, but the default branch is `main`

## Expected effect

| PR type | Before | After |
|---|---:|---:|
| git / zlib / curl / expat / pcre2 / GHA action bump | ~9 min | **~3 min** |
| gettext bump (rare, ~yearly) | ~9 min | ~9 min (unavoidable) |
| `gettext_configs` edit | ~9 min | ~9 min (hash auto-invalidates correctly) |

## Test plan

Cache save is gated on `github.ref_name == 'main'` so feature branches don't pollute the cache (matches the convention used in `sasaplus1/macos-vim`). This means the speed benefit is only observable **after** merging this PR and on subsequent PRs — not on this PR's own runs.

- [ ] First CI run on this PR (cache miss expected): green on macos-14 / macos-15, total time comparable to current (~9 min). Goal here is correctness, not speed
- [ ] Artifact `git --version` reports `2.54.0`; `git --version --build-options` shows `gettext: enabled`
- [ ] `otool -L ./usr/bin/git` shows only macOS frameworks and libSystem (no leaked dylibs from Homebrew or our build tree)
- [ ] After merging: main's CI run saves the gettext cache for the first time
- [ ] Next PR (Renovate or a small follow-up): gettext cache hit observed in logs (`Cache restored successfully`), `make install-gettext` reports `Nothing to be done` in <1s, total CI ~3 min
- [x] Locally, after a full `make install`, re-running `make install-gettext` is a no-op in 0.025s (verified before submitting)

## Out of scope

- Caching the other deps (zlib/curl/expat/pcre2/git) — each is individually fast, the marginal CI win does not justify the per-dep cache plumbing
- Applying the same pattern to sibling repos (`macos-vim`, `macos-tmux`, `macos-bash`) — separate PRs
- `hendrikmuhs/ccache-action` Node.js 20 deprecation warning — separate concern

🤖 Generated with [Claude Code](https://claude.com/claude-code)